### PR TITLE
Be less strict with link tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function(options) {
 			getFileName: function(node) { return node.attr('src'); }
 		},
 		css : {
-			selector: 'link[type="text/css"][rel=stylesheet]:not([data-ignore=true], [data-remove=true])',
+			selector: 'link[rel=stylesheet]:not([data-ignore=true], [data-remove=true])',
 			getFileName: function(node) { return node.attr('href'); }
 		}
 	}


### PR DESCRIPTION
Thanks for the great plugin.

The type attribute on stylesheet links is not required in HTML5 so it wasn't picking up my css until I made this change.